### PR TITLE
CS-22 Add New Song -> Replace Type with Tags

### DIFF
--- a/src/components/CategoryBadge/CategoryBadge.jsx
+++ b/src/components/CategoryBadge/CategoryBadge.jsx
@@ -1,5 +1,18 @@
 import { CategoryBadgeContainer } from './CategoryBadge.styles';
 
-const CategoryBadge = ({ category }) => <CategoryBadgeContainer>{category}</CategoryBadgeContainer>;
+// const CategoryBadge = ({ category }) => <CategoryBadgeContainer>{category}</CategoryBadgeContainer>;
+
+const CategoryBadge = ({ tags }) => {
+    
+    return (
+    <>
+  {tags && tags.map((tag, i) => {
+    return <CategoryBadgeContainer key={i}>{tag}</CategoryBadgeContainer>
+  })}
+    
+    </>
+    )
+}
+
 
 export default CategoryBadge;

--- a/src/components/CategoryBadge/CategoryBadge.styles.jsx
+++ b/src/components/CategoryBadge/CategoryBadge.styles.jsx
@@ -4,6 +4,8 @@ export const CategoryBadgeContainer = styled.span`
     text-transform: uppercase;
     background: #416a59;
     padding: 2px 7px;
+    display: block;
+    margin: 5px 0;
     border-radius: 4px;
     color: #fff;
     font-size: 12px;

--- a/src/components/DisplaySongsTable/CustomTableHead/CustomTableHead.jsx
+++ b/src/components/DisplaySongsTable/CustomTableHead/CustomTableHead.jsx
@@ -36,10 +36,10 @@ const CustomTableHead = props => {
             label: 'Title',
         },
         {
-            id: 'category',
+            id: 'tags',
             numeric: false,
             disablePadding: false,
-            label: 'Category',
+            label: 'Tags',
         },
         {
             id: 'rating',

--- a/src/components/DisplaySongsTable/DisplaySongRow/DisplaytSongRow.jsx
+++ b/src/components/DisplaySongsTable/DisplaySongRow/DisplaytSongRow.jsx
@@ -31,7 +31,7 @@ const DisplaySongRow = ({ song }) => {
     const [author, setAuthor] = useState({});
     const [isUserLogged, setIsUserLogged] = useState(false);
     const navigate = useNavigate();
-    const { title, id, addedBy, createdAt, category } = song;
+    const { title, id, addedBy, createdAt, category, tags } = song;
 
     useEffect(() => {
         const unsubscribe = onAuthStateChangedListener(user => {
@@ -65,7 +65,8 @@ const DisplaySongRow = ({ song }) => {
                 </TableCell>
                 <TableCell align="left">{title}</TableCell>
                 <TableCell align="left">
-                    <CategoryBadge category={category} />
+                    {/* <CategoryBadge category={category} /> */}
+                    <CategoryBadge tags={tags} />
                 </TableCell>
                 <TableCell align="left">
                     <HalfRating readOnly value={roundHalf(song.rating.score / song.rating.votes)} />

--- a/src/components/DisplaySongsTable/DisplaySongsTable.jsx
+++ b/src/components/DisplaySongsTable/DisplaySongsTable.jsx
@@ -23,17 +23,16 @@ const DisplaySongsTable = ({ data, types }) => {
     const [orderBy, setOrderBy] = useState('createdAt');
     const [page, setPage] = useState(0);
     const [rowsPerPage, setRowsPerPage] = useState(15);
-    const [selected, setSelected] = useState([]);
-    const [categories, setCategories] = useState(
-        types || ['corrido', 'ladainha', 'maculele', 'quadra', 'samba'],
-    );
-    const [loading, setLoading] = useState(true);
+    // const [selected, setSelected] = useState([]);
+    // const [categories, setCategories] = useState(
+    //     types || ['corrido', 'ladainha', 'maculele', 'quadra', 'samba'],
+    // );
+    // const [loading, setLoading] = useState(true);
     const [filteredData, setData] = useState([]);
 
     useEffect(() => {
         if (types) {
             // setData(data.filter(song => types.includes(song.category)));
-            console.log(types)
             setData(data.filter(song => song.tags?.some(tag => types.includes(tag))));
         } else {
             setData(data);
@@ -87,10 +86,10 @@ const DisplaySongsTable = ({ data, types }) => {
         setPage(0);
     };
 
-    const handleData = () => {
-        const foo = data.filter(song => types.includes(song.category));
-        return foo;
-    };
+    // const handleData = () => {
+    //     const foo = data.filter(song => types.includes(song.category));
+    //     return foo;
+    // };
 
     console.log(filteredData)
     return (
@@ -116,7 +115,6 @@ const DisplaySongsTable = ({ data, types }) => {
             <TablePagination
                 rowsPerPageOptions={[5, 10, 25]}
                 component="div"
-                // count={data.length}
                 count={filteredData.length}
                 rowsPerPage={rowsPerPage}
                 page={page}

--- a/src/components/DisplaySongsTable/DisplaySongsTable.jsx
+++ b/src/components/DisplaySongsTable/DisplaySongsTable.jsx
@@ -32,11 +32,15 @@ const DisplaySongsTable = ({ data, types }) => {
 
     useEffect(() => {
         if (types) {
-            setData(data.filter(song => types.includes(song.category)));
+            // setData(data.filter(song => types.includes(song.category)));
+            console.log(types)
+            setData(data.filter(song => song.tags?.some(tag => types.includes(tag))));
         } else {
             setData(data);
         }
     }, [types, data]);
+
+
 
     const handleRequestSort = (event, property) => {
         const isAsc = orderBy === property && order === 'asc';
@@ -88,6 +92,7 @@ const DisplaySongsTable = ({ data, types }) => {
         return foo;
     };
 
+    console.log(filteredData)
     return (
         <>
             <TableContainer>
@@ -96,7 +101,7 @@ const DisplaySongsTable = ({ data, types }) => {
                         order={order}
                         orderBy={orderBy}
                         onRequestSort={handleRequestSort}
-                        rowCount={data.length}
+                        rowCount={data.length}          
                     />
                     <TableBody>
                         {stableSort(filteredData, getComparator(order, orderBy))
@@ -111,7 +116,8 @@ const DisplaySongsTable = ({ data, types }) => {
             <TablePagination
                 rowsPerPageOptions={[5, 10, 25]}
                 component="div"
-                count={data.length}
+                // count={data.length}
+                count={filteredData.length}
                 rowsPerPage={rowsPerPage}
                 page={page}
                 onPageChange={handleChangePage}

--- a/src/pages/AddSong/AddSong.jsx
+++ b/src/pages/AddSong/AddSong.jsx
@@ -11,6 +11,9 @@ import {
     RadioGroup,
     Radio,
     Tooltip,
+    Stack,
+    Autocomplete,
+    TextField,
 } from '@mui/material';
 
 import {
@@ -70,9 +73,16 @@ const AddSong = () => {
         formState: { errors },
     } = useForm({
         defaultValues: {
-            category: '',
+            category: [],
         },
     });
+
+    const categoryOptions = [
+        { value: 'corrido', label: 'Corrido' },
+        { value: 'ladainha', label: 'Ladainha' },
+        { value: 'maculele', label: 'Maculele' },
+        { value: 'samba', label: 'Samba de Roda' },
+    ];
 
     useEffect(() => {
         const updateUserDb = onAuthStateChangedListener(user => {
@@ -96,7 +106,7 @@ const AddSong = () => {
         }).format(timestamp);
 
         const songToAdd = {
-            category,
+            category: category.map(tag => tag.value),
             title,
             createdAt: timestampFormat,
             youtube,
@@ -108,7 +118,7 @@ const AddSong = () => {
             },
             lyrics: { ...rest },
         };
-        addSongToDb(songToAdd, category);
+        addSongToDb(songToAdd);
         reset();
     };
 
@@ -141,46 +151,45 @@ const AddSong = () => {
         textInputs.map(input => unregister(`${input}-b`));
     };
 
+    console.log(watch('category'));
+
     return (
         <>
             {/* "handleSubmit" will validate your inputs before invoking "onSubmit" */}
             <AddSongContainer>
                 <AddSongForm onSubmit={handleSubmit(onSubmit)}>
-                    <FormControl component="fieldset">
-                        <FormLabel component="legend">Type:</FormLabel>
+
+                    <Stack>
                         <Controller
-                            rules={{ required: true }}
-                            control={control}
                             name="category"
-                            render={({ field }) => {
-                                return (
-                                    <RadioContainer as={RadioGroup} {...field}>
-                                        <FormControlLabel
-                                            value="corrido"
-                                            control={<Radio />}
-                                            label="Corrido"
-                                        />
-                                        <FormControlLabel
-                                            value="ladainha"
-                                            control={<Radio />}
-                                            label="Ladainha"
-                                        />
-                                        <FormControlLabel
-                                            value="maculele"
-                                            control={<Radio />}
-                                            label="Maculele"
-                                        />
-                                        <FormControlLabel value="quadra" control={<Radio />} label="Quadra" />
-                                        <FormControlLabel
-                                            value="samba"
-                                            control={<Radio />}
-                                            label="Samba de Roda"
-                                        />
-                                    </RadioContainer>
-                                );
+                            control={control}
+                            rules={{
+                                required: true,
+                                message: 'Choose tags',
                             }}
+                            render={({ field: { onChange, value }, fieldState: { error } }) => (
+                                <Autocomplete
+                                    onChange={(e, data) => onChange(data)}
+                                    value={value}
+                                    multiple
+                                    id="category"
+                                    options={categoryOptions}
+                                    getOptionLabel={option => option.label}
+                                    isOptionEqualToValue={(option, value) => option.value === value.value}
+                                    defaultValue={[]}
+                                    filterSelectedOptions
+                                    renderInput={params => (
+                                        <TextField
+                                            {...params}
+                                            label="Choose category tags"
+                                            placeholder="Category tags"
+                                            error={!!error}
+                                        />
+                                    )}
+                                />
+                            )}
                         />
-                    </FormControl>
+                    </Stack>
 
                     {/* register your input into the hook by invoking the "register" function */}
                     <TitleContainer>

--- a/src/pages/AddSong/AddSong.jsx
+++ b/src/pages/AddSong/AddSong.jsx
@@ -73,11 +73,12 @@ const AddSong = () => {
         formState: { errors },
     } = useForm({
         defaultValues: {
-            category: [],
+            category: "",
+            tags: []
         },
     });
 
-    const categoryOptions = [
+    const tagOptions = [
         { value: 'corrido', label: 'Corrido' },
         { value: 'ladainha', label: 'Ladainha' },
         { value: 'maculele', label: 'Maculele' },
@@ -97,7 +98,7 @@ const AddSong = () => {
     }, [currentUser]);
 
     const onSubmit = data => {
-        const { title, category, youtube, ...rest } = data;
+        const { title, category, tags, youtube, ...rest } = data;
         const timestamp = Date.now(); // This would be the timestamp you want to format
         const timestampFormat = new Intl.DateTimeFormat('en-US', {
             year: 'numeric',
@@ -106,7 +107,8 @@ const AddSong = () => {
         }).format(timestamp);
 
         const songToAdd = {
-            category: category.map(tag => tag.value),
+            category, 
+            tags: tags.map(tag => tag.value),
             title,
             createdAt: timestampFormat,
             youtube,
@@ -151,7 +153,7 @@ const AddSong = () => {
         textInputs.map(input => unregister(`${input}-b`));
     };
 
-    console.log(watch('category'));
+    console.log(watch('tags'));
 
     return (
         <>
@@ -161,7 +163,7 @@ const AddSong = () => {
 
                     <Stack>
                         <Controller
-                            name="category"
+                            name="tags"
                             control={control}
                             rules={{
                                 required: true,
@@ -172,8 +174,8 @@ const AddSong = () => {
                                     onChange={(e, data) => onChange(data)}
                                     value={value}
                                     multiple
-                                    id="category"
-                                    options={categoryOptions}
+                                    id="tags"
+                                    options={tagOptions}
                                     getOptionLabel={option => option.label}
                                     isOptionEqualToValue={(option, value) => option.value === value.value}
                                     defaultValue={[]}
@@ -181,8 +183,8 @@ const AddSong = () => {
                                     renderInput={params => (
                                         <TextField
                                             {...params}
-                                            label="Choose category tags"
-                                            placeholder="Category tags"
+                                            label="Choose tags"
+                                            placeholder="Tags"
                                             error={!!error}
                                         />
                                     )}

--- a/src/pages/AddSong/AddSong.jsx
+++ b/src/pages/AddSong/AddSong.jsx
@@ -83,6 +83,7 @@ const AddSong = () => {
         { value: 'ladainha', label: 'Ladainha' },
         { value: 'maculele', label: 'Maculele' },
         { value: 'samba', label: 'Samba de Roda' },
+        { value: 'quadras', label: 'Quadras' }
     ];
 
     useEffect(() => {

--- a/src/pages/Songbook/Songbook.jsx
+++ b/src/pages/Songbook/Songbook.jsx
@@ -61,8 +61,6 @@ const Songbook = () => {
         }
     };
     
-    const tags = ['corrido', 'ladainha', 'maculele', 'samba', 'quadras'];
-console.log(results)
     return (
         <SongbookContainer>
             <SearchForm
@@ -74,9 +72,7 @@ console.log(results)
                 {isLoading ? (
                     <LoadingCircle />
                 ) : (
-                    // <DisplaySongsTable data={results} types={checkboxesValues} />
-                    // <DisplaySongsTable data={results} types={['ladainha']} />
-                    <DisplaySongsTable data={results} types={null} />
+                    <DisplaySongsTable data={results} types={checkboxesValues} />
                 )}
             </TableContainer>
         </SongbookContainer>

--- a/src/pages/Songbook/Songbook.jsx
+++ b/src/pages/Songbook/Songbook.jsx
@@ -60,7 +60,9 @@ const Songbook = () => {
             setCheckboxesValues(checkboxesValues.filter(type => type !== value));
         }
     };
-
+    
+    const tags = ['corrido', 'ladainha', 'maculele', 'samba', 'quadras'];
+console.log(results)
     return (
         <SongbookContainer>
             <SearchForm
@@ -72,7 +74,9 @@ const Songbook = () => {
                 {isLoading ? (
                     <LoadingCircle />
                 ) : (
-                    <DisplaySongsTable data={results} types={checkboxesValues} />
+                    // <DisplaySongsTable data={results} types={checkboxesValues} />
+                    // <DisplaySongsTable data={results} types={['ladainha']} />
+                    <DisplaySongsTable data={results} types={null} />
                 )}
             </TableContainer>
         </SongbookContainer>


### PR DESCRIPTION
Sorry, I've named the branch as CS-22, but actually I have completed 2 sub tasks by now:

CS-22/CS-50 Replace type radio inputs with Mui Autocomplete input
CS-22/CS-23 Add a new endpoint Tags to the song (firestore and redux)

TO DO next:
CS-22/CS-24 Songs Table -> Add functionality to filter by Tags insted of Type
Also we need to change table logic to display songs with tags added. Currently, songs with tags instead of category are being added to firestore & redux, but they are not displayed in table.
